### PR TITLE
[FE] feat: url로 페이지 접근 시 nav ui 변경

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -78,27 +77,20 @@ const StyledLink = styled(Link)`
   }
 `;
 
-const Nav = () => {
-  const [curPage, setCurPage] = useState(0);
-  const handleClickHome = () => {
-    setCurPage(0);
-  };
-  const handleClickQuestions = () => {
-    setCurPage(1);
-  };
-  const handleClickTags = () => {
-    setCurPage(2);
-  };
-  const handleClickUsers = () => {
-    setCurPage(3);
-  };
+const navObj = {
+  home: '/',
+  questions: '/questions',
+  tags: '/tags',
+  users: '/users',
+};
+
+const Nav = ({ pathname = navObj.home }) => {
   return (
     <NavWrapper>
       <NavContainerBox>
-        <StyledLink to="/">
+        <StyledLink to={`${navObj.home}`}>
           <NavContainer
-            className={curPage === 0 ? 'selected' : ''}
-            onClick={handleClickHome}
+            className={pathname === `${navObj.home}` ? 'selected' : ''}
           >
             Home
           </NavContainer>
@@ -106,10 +98,11 @@ const Nav = () => {
       </NavContainerBox>
       <NavContainerBox>
         <Public>PUBLIC</Public>
-        <StyledLink to="/questions">
+        <StyledLink to={`${navObj.questions}`}>
           <NavContainer
-            className={curPage === 1 ? 'selected' : ''}
-            onClick={handleClickQuestions}
+            className={
+              pathname.startsWith(`${navObj.questions}`) ? 'selected' : ''
+            }
           >
             <svg aria-hidden="true" width="18" height="18" viewBox="0 0 18 18">
               <path d="M9 1C4.64 1 1 4.64 1 9c0 4.36 3.64 8 8 8 4.36 0 8-3.64 8-8 0-4.36-3.64-8-8-8ZM8 15.32a6.46 6.46 0 0 1-4.3-2.74 6.46 6.46 0 0 1-.93-5.01L7 11.68v.8c0 .88.12 1.32 1 1.32v1.52Zm5.72-2c-.2-.66-1-1.32-1.72-1.32h-1v-2c0-.44-.56-1-1-1H6V7h1c.44 0 1-.56 1-1V5h2c.88 0 1.4-.72 1.4-1.6v-.33a6.45 6.45 0 0 1 3.83 4.51 6.45 6.45 0 0 1-1.51 5.73v.01Z"></path>
@@ -117,18 +110,16 @@ const Nav = () => {
             <span>Questions</span>
           </NavContainer>
         </StyledLink>
-        <StyledLink to="/tags">
+        <StyledLink to={`${navObj.tags}`}>
           <NavContainer
-            className={curPage === 2 ? 'selected blank' : 'blank'}
-            onClick={handleClickTags}
+            className={pathname.startsWith(`${navObj.tags}`) ? 'selected' : ''}
           >
             Tags
           </NavContainer>
         </StyledLink>
-        <StyledLink to="/users">
+        <StyledLink to={`${navObj.users}`}>
           <NavContainer
-            className={curPage === 3 ? 'selected blank' : 'blank'}
-            onClick={handleClickUsers}
+            className={pathname.startsWith(`${navObj.users}`) ? 'selected' : ''}
           >
             Users
           </NavContainer>

--- a/client/src/components/PageContainer.js
+++ b/client/src/components/PageContainer.js
@@ -1,3 +1,4 @@
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Nav from './Nav';
@@ -74,10 +75,12 @@ const PageContainer = ({
   containerClassName,
   contentClassName,
 }) => {
+  const location = useLocation();
+
   return (
     <>
       <Container className={containerClassName}>
-        {nav ? <Nav /> : null}
+        {nav ? <Nav pathname={location.pathname} /> : null}
         <Content className={contentClassName}>
           {children}
           {sidebar ? <Sidebar /> : null}


### PR DESCRIPTION
주소창에 주소 입력하여 페이지에 접근 시 Nav ui 변경되도록 처리하였습니다.
PageContainer를 사용하지 않으시고 Nav 컴포넌트를 직접 사용하시는 경우
```javascript
import { useLocation } from 'react-router-dom';
  const location = useLocation();
<Nav pathname={location.pathname} />
```
위와 같이 Nav 컴포넌트에 pathname props를 넘겨주시기 바랍니다.

- 확인된 적용되어야 할 페이지
  - @jwo0o0 /questions/:id