### PR TITLE
[BE] fix: Question-Answer, Question-Comment, Answer-Comment 양방향 매핑으로 변경

### DIFF
--- a/server/src/main/java/com/codestates/answer/dto/AnswerResponseDto.java
+++ b/server/src/main/java/com/codestates/answer/dto/AnswerResponseDto.java
@@ -1,12 +1,14 @@
 package com.codestates.answer.dto;
 
 import com.codestates.answer.entity.Answer;
+import com.codestates.comment.entity.Comment;
 import com.codestates.user.dto.UserDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 @Getter
@@ -22,6 +24,8 @@ public class AnswerResponseDto {
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    private List<Comment> comments;
 
     private UserDto.Response userResponseDto;
 }

--- a/server/src/main/java/com/codestates/answer/entity/Answer.java
+++ b/server/src/main/java/com/codestates/answer/entity/Answer.java
@@ -5,6 +5,8 @@ import com.codestates.user.entity.User;
 import com.codestates.question.Question;
 import com.codestates.comment.entity.Comment;
 import com.codestates.vote.AnswerVote.AnswerVote;
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,11 +29,13 @@ public class Answer extends Auditable {
     @Column(nullable = false, name = "status")
     private AnswerStatus answerStatus = AnswerStatus.ANSWER_NORMAL;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @JsonBackReference
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
 
@@ -44,14 +48,7 @@ public class Answer extends Auditable {
     @Column(nullable = false, name = "LAST_MODIFIED_AT")
     private LocalDateTime modifiedAt = LocalDateTime.now();
 
-    public void addUser(User user) {
-        this.user = user;
-    }
-
-    public void addQuestion(Question question) {
-        this.question = question;
-    }
-
+    @JsonManagedReference
     @OneToMany(mappedBy = "answer")
     private List<Comment> comments = new ArrayList<>();
 

--- a/server/src/main/java/com/codestates/answer/mapper/AnswerMapper.java
+++ b/server/src/main/java/com/codestates/answer/mapper/AnswerMapper.java
@@ -47,6 +47,7 @@ public interface AnswerMapper {
                 .vote(answer.getVote())
                 .createdAt(answer.getCreatedAt())
                 .modifiedAt(answer.getModifiedAt())
+                .comments(answer.getComments())
                 .userResponseDto(userToUserResponseDto(user))
                 .build();
     }

--- a/server/src/main/java/com/codestates/comment/entity/Comment.java
+++ b/server/src/main/java/com/codestates/comment/entity/Comment.java
@@ -4,6 +4,7 @@ import com.codestates.answer.entity.Answer;
 import com.codestates.audit.Auditable;
 import com.codestates.user.entity.User;
 import com.codestates.question.Question;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,14 +31,17 @@ public class Comment extends Auditable {
     @Column(nullable = false)
     private String body;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
 
+    @JsonBackReference
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "answer_id")
     private Answer answer;
 
+    @JsonBackReference
     @ManyToOne(fetch =  FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/server/src/main/java/com/codestates/question/Question.java
+++ b/server/src/main/java/com/codestates/question/Question.java
@@ -6,6 +6,7 @@ import com.codestates.user.entity.User;
 import com.codestates.comment.entity.Comment;
 import com.codestates.vote.QuestionVote.QuestionVote;
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
 import javax.persistence.*;
@@ -59,9 +60,11 @@ public class Question extends Auditable {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
     private List<Answer> answers = new ArrayList<>();
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "question")
     private List<Comment> comments = new ArrayList<>();
 

--- a/server/src/main/java/com/codestates/question/QuestionDto.java
+++ b/server/src/main/java/com/codestates/question/QuestionDto.java
@@ -70,7 +70,7 @@ public class QuestionDto {
 //        private String nickName;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
-        private List<Answer> answers;
+//        private List<Answer> answers;
         private List<Comment> comments;
         //        private Set<QuestionTag> tags;
         /*멤버&답변&댓글 추가할 것!*/

--- a/server/src/main/java/com/codestates/question/QuestionMapper.java
+++ b/server/src/main/java/com/codestates/question/QuestionMapper.java
@@ -59,7 +59,7 @@ public interface QuestionMapper {
                 .createdAt(question.getCreatedAt())
                 .modifiedAt(question.getModifiedAt())
 //                .answers(question.getAnswers())
-//                .comments(question.getComments())
+                .comments(question.getComments())
 //                .tags(tagToTagResponseDto())
 //                .tags(question.getQuestionTags())
 //                .tagResponseDto(tagToTagResponseDto(tag))

--- a/server/src/main/java/com/codestates/user/entity/User.java
+++ b/server/src/main/java/com/codestates/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.codestates.user.entity;
 
+import com.codestates.answer.entity.Answer;
 import com.codestates.audit.Auditable;
 import com.codestates.comment.entity.Comment;
 import com.codestates.question.Question;
@@ -46,8 +47,13 @@ public class User extends Auditable {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Question> questions = new ArrayList<>();
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<Comment> replies = new ArrayList<>();
+    private List<Answer> answers = new ArrayList<>();
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
 
     public User(String nickName, String email, String password) {
         this.nickName = nickName;


### PR DESCRIPTION
Question-Answer, Question-Comment, Answer-Comment 양방향 매핑으로 변경
-> Question과 Answer의 response body에서 각각에 해당하는 comments를 확인할 수 있습니다

- Question
<img width="820" alt="화면 캡처 2022-10-31 180957" src="https://user-images.githubusercontent.com/39071652/198973369-45da2975-f17d-41d3-8ba6-d504222c9bec.png">


- Answer
<img width="827" alt="화면 캡처 2022-10-31 180929" src="https://user-images.githubusercontent.com/39071652/198973200-4eec3e6a-ae55-4e04-b72c-a83003e29efc.png">